### PR TITLE
Update Tomcat to 10.1.39

### DIFF
--- a/opensuse-tomcat-jre21-image/pom.xml
+++ b/opensuse-tomcat-jre21-image/pom.xml
@@ -121,11 +121,6 @@
                                     </inline>
                                 </assembly>
                                 <args>
-                                    <!-- Enable internet access -->
-                                    <http_proxy>${env.HTTP_PROXY}</http_proxy>
-                                    <https_proxy>${env.HTTPS_PROXY}</https_proxy>
-                                    <no_proxy>${env.NO_PROXY}</no_proxy>
-                                    
                                     <!-- Pass in opensuse-tomcat-jre21-juli image as param -->
                                     <JULI_IMAGE>${dockerCafImagePrefix}opensuse-tomcat-jre21-juli${dockerProjectVersion}</JULI_IMAGE>
                                 </args>
@@ -170,4 +165,35 @@
             </plugin>
         </plugins>
     </build>
+    <profiles>
+        <!-- profile for docker proxy settings -->
+        <profile>
+            <id>docker-proxy</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>io.fabric8</groupId>
+                        <artifactId>docker-maven-plugin</artifactId>
+                        <configuration>
+                            <images>
+                                <image>
+                                    <build>
+                                        <args>
+                                            <!-- Enable internet access -->
+                                            <http_proxy>${env.HTTP_PROXY}</http_proxy>
+                                            <https_proxy>${env.HTTPS_PROXY}</https_proxy>
+                                            <no_proxy>${env.NO_PROXY}</no_proxy>
+                                        </args>
+                                    </build>
+                                </image>
+                            </images>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>

--- a/opensuse-tomcat-jre21-juli-image/pom.xml
+++ b/opensuse-tomcat-jre21-juli-image/pom.xml
@@ -76,12 +76,6 @@
                             <name>${dockerCafImagePrefix}opensuse-tomcat-jre21-juli${dockerProjectVersion}</name>
                             <build>
                                 <dockerFileDir>.</dockerFileDir>
-                                <args>
-                                    <!-- Enable internet access -->
-                                    <http_proxy>${env.HTTP_PROXY}</http_proxy>
-                                    <https_proxy>${env.HTTPS_PROXY}</https_proxy>
-                                    <no_proxy>${env.NO_PROXY}</no_proxy>
-                                </args>
                             </build>
                         </image>
                         <image>
@@ -123,4 +117,35 @@
             </plugin>
         </plugins>
     </build>
+    <profiles>
+        <!-- profile for docker proxy settings -->
+        <profile>
+            <id>docker-proxy</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>io.fabric8</groupId>
+                        <artifactId>docker-maven-plugin</artifactId>
+                        <configuration>
+                            <images>
+                                <image>
+                                    <build>
+                                        <args>
+                                            <!-- Enable internet access -->
+                                            <http_proxy>${env.HTTP_PROXY}</http_proxy>
+                                            <https_proxy>${env.HTTPS_PROXY}</https_proxy>
+                                            <no_proxy>${env.NO_PROXY}</no_proxy>
+                                        </args>
+                                    </build>
+                                </image>
+                            </images>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>

--- a/opensuse-tomcat-jre21-juli-image/src/main/docker/Dockerfile
+++ b/opensuse-tomcat-jre21-juli-image/src/main/docker/Dockerfile
@@ -27,13 +27,13 @@ ENV TOMCAT_ROOT_DIR $TOMCAT_PARENT_DIR/$TOMCAT_DIR_NAME
 ENV TOMCAT_CONF_DIR $TOMCAT_ROOT_DIR/conf
 
 # Download, extract Tomcat and remove unwanted web applications
-RUN curl -fsSL -o /wd/apache-tomcat-10.1.34.tar.gz https://archive.apache.org/dist/tomcat/tomcat-10/v10.1.34/bin/apache-tomcat-10.1.34.tar.gz && \
-    echo e29c4d0e26295d64dfeee399e7719b5baac2682ac0e7b53702f26d630fea761f93ddf60674dfe87c41ddd9b79d4938a6a533a280bb3d7fb83c2a1b7cd5da6b09 \
-        /wd/apache-tomcat-10.1.34.tar.gz | sha512sum -c - && \
+RUN curl -fsSL -o /wd/apache-tomcat-10.1.39.tar.gz https://archive.apache.org/dist/tomcat/tomcat-10/v10.1.39/bin/apache-tomcat-10.1.39.tar.gz && \
+    echo 55998c7e906a37340f4b56ca66d4a1ef7c0f7a061a9b868e7ed90cce8188f469495ee590d9971eb8d9870dc34ed89b63d6b870a281cb7e84de14a7555fc100e1 \
+        /wd/apache-tomcat-10.1.39.tar.gz | sha512sum -c - && \
     mkdir -p $TOMCAT_PARENT_DIR && \
     cd $TOMCAT_PARENT_DIR && \
-    tar xzf /wd/apache-tomcat-10.1.34.tar.gz && \
-    mv apache-tomcat-10.1.34 $TOMCAT_DIR_NAME && \
+    tar xzf /wd/apache-tomcat-10.1.39.tar.gz && \
+    mv apache-tomcat-10.1.39 $TOMCAT_DIR_NAME && \
     cd $TOMCAT_ROOT_DIR/webapps && \
     rm -rf docs/ examples/ host-manager/ manager/
 

--- a/opensuse-tomcat-jre21-juli-image/src/main/docker/server.xslt
+++ b/opensuse-tomcat-jre21-juli-image/src/main/docker/server.xslt
@@ -47,12 +47,14 @@
             SSLEnabled="true"
             scheme="https"
             secure="true"
-            keystoreFile="/keystore/tomcat.keystore"
-            keystorePass="changeit"
-            keyPass="changeit"
-            clientAuth="false"
-            keyAlias="tomcat"
-            sslProtocol="TLS" />
+            clientAuth="false"&gt;
+        &lt;SSLHostConfig sslProtocol="TLS"&gt;
+            &lt;Certificate certificateKeystoreFile="/keystore/tomcat.keystore"
+                certificateKeystorePassword="changeit"
+                certificateKeyPassword="changeit"
+                certificateKeyAlias="tomcat"/&gt;
+        &lt;/SSLHostConfig&gt;
+    &lt;/Connector&gt;
             setup-tomcat-ssl-cert.sh TLS section end </xsl:comment>
         <xsl:text>
         </xsl:text>
@@ -113,4 +115,3 @@
         </Service>
     </xsl:template>
 </xsl:stylesheet>
-

--- a/opensuse-tomcat-jre21-juli-image/src/main/docker/startup.d/setup-tomcat-ssl-cert.sh
+++ b/opensuse-tomcat-jre21-juli-image/src/main/docker/startup.d/setup-tomcat-ssl-cert.sh
@@ -37,26 +37,26 @@ then
 
     # Replace the default keystore with the SSL_TOMCAT_CA_CERT_LOCATION keystore provided
     echo "Replacing default keystore in $CATALINA_HOME/conf/server.xml with provided environment variable SSL_TOMCAT_CA_CERT_LOCATION."
-    sed -i "s@keystoreFile=.*@keystoreFile=\"$SSL_TOMCAT_CA_CERT_LOCATION\"@" $CATALINA_HOME/conf/server.xml
+    sed -i "s@certificateKeystoreFile=.*@certificateKeystoreFile=\"$SSL_TOMCAT_CA_CERT_LOCATION\"@" $CATALINA_HOME/conf/server.xml
 
     # Replace default password with a user defined password if provided
     if [ -n "${SSL_TOMCAT_CA_CERT_KEYSTORE_PASS}" ]
     then
         echo "Replacing keystore pass in $CATALINA_HOME/conf/server.xml with provided environment variable SSL_TOMCAT_CA_CERT_KEYSTORE_PASS"
-        awk -v new_pass="$SSL_TOMCAT_CA_CERT_KEYSTORE_PASS" '/keystorePass=/ {sub(/keystorePass=.*/, "keystorePass=\"" new_pass "\"")} 1' $CATALINA_HOME/conf/server.xml > temp_file && mv temp_file $CATALINA_HOME/conf/server.xml
+        awk -v new_pass="$SSL_TOMCAT_CA_CERT_KEYSTORE_PASS" '/certificateKeystorePassword=/ {sub(/certificateKeystorePassword=.*/, "certificateKeystorePassword=\"" new_pass "\"")} 1' $CATALINA_HOME/conf/server.xml > temp_file && mv temp_file $CATALINA_HOME/conf/server.xml
     fi
 
     # Replace default password with a user defined password if provided
     if [ -n "${SSL_TOMCAT_CA_CERT_KEY_PASS}" ]
     then
         echo "Replacing key pass in $CATALINA_HOME/conf/server.xml with provided environment variable SSL_TOMCAT_CA_CERT_KEY_PASS"
-        awk -v new_pass="$SSL_TOMCAT_CA_CERT_KEY_PASS" '/keyPass=/ {sub(/keyPass=.*/, "keyPass=\"" new_pass "\"")} 1' $CATALINA_HOME/conf/server.xml > temp_file && mv temp_file $CATALINA_HOME/conf/server.xml
+        awk -v new_pass="$SSL_TOMCAT_CA_CERT_KEY_PASS" '/certificateKeyPassword=/ {sub(/certificateKeyPassword=.*/, "certificateKeyPassword=\"" new_pass "\"")} 1' $CATALINA_HOME/conf/server.xml > temp_file && mv temp_file $CATALINA_HOME/conf/server.xml
     fi
 
     # Replace default alias with a user defined alias if provided
     if [ -n "${SSL_TOMCAT_CA_CERT_KEYSTORE_ALIAS}" ]
     then
         echo "Replacing keystore alias in $CATALINA_HOME/conf/server.xml with provided environment variable SSL_TOMCAT_CA_CERT_KEYSTORE_ALIAS"
-        sed -i "s@keyAlias=.*@keyAlias=\"$SSL_TOMCAT_CA_CERT_KEYSTORE_ALIAS\"@" $CATALINA_HOME/conf/server.xml
+        sed -i "s@certificateKeyAlias=.*@certificateKeyAlias=\"$SSL_TOMCAT_CA_CERT_KEYSTORE_ALIAS\"@" $CATALINA_HOME/conf/server.xml
     fi
 fi

--- a/pom.xml
+++ b/pom.xml
@@ -125,7 +125,7 @@
             <dependency>
                 <groupId>com.github.tomcat-slf4j-logback</groupId>
                 <artifactId>tomcat10-slf4j-logback</artifactId>
-                <version>10.1.34</version>
+                <version>10.1.39</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.commons</groupId>
@@ -140,7 +140,7 @@
             <dependency>
                 <groupId>org.apache.tomcat</groupId>
                 <artifactId>tomcat-juli</artifactId>
-                <version>10.1.34</version>
+                <version>10.1.39</version>
             </dependency>
             <dependency>
                 <groupId>org.slf4j</groupId>

--- a/release-notes-1.0.0.md
+++ b/release-notes-1.0.0.md
@@ -6,5 +6,6 @@ ${version-number}
 #### New Features
 
 - New Tomcat jre21 image
+  - Tomcat 10.1.39.
 
 #### Known Issues


### PR DESCRIPTION
## Overview

This change updates the project to use Tomcat 10.1.39. It also updates the TLS def in the server.xml to avoid errors in Tomcat attempting to use a default SSL host config.

```xml
        <!-- setup-tomcat-ssl-cert.sh TLS section start
    <Connector port="8443"
            protocol="org.apache.coyote.http11.Http11NioProtocol"
            SSLEnabled="true"
            scheme="https"
            secure="true"
            clientAuth="false">
        <SSLHostConfig sslProtocol="TLS">
            <Certificate certificateKeystoreFile="/keystore/tomcat.keystore"
                certificateKeystorePassword="changeit"
                certificateKeyPassword="changeit"
                certificateKeyAlias="tomcat"/>
        </SSLHostConfig>
    </Connector>
            setup-tomcat-ssl-cert.sh TLS section end -->
```

## Source change summary
 
- Use tomcat 10.1.39.
- Move args for docker proxy settings in docker-maven-plugin to a new profile, enabled by default.
- Alter SSL config in server.xml to match the preferred declaration, to avoid errors searching for a default SSLHostConfig.
- Updated the setup-tomcat-ssl-cert.sh script to update the new keystore args in the new server.xml approach.