### PR TITLE
Activate the Maven proxy profile using the HTTP_PROXY env variable

### DIFF
--- a/opensuse-tomcat-jre21-image/pom.xml
+++ b/opensuse-tomcat-jre21-image/pom.xml
@@ -170,7 +170,6 @@
         <profile>
             <id>docker-proxy</id>
             <activation>
-                <activeByDefault>false</activeByDefault>
                 <property>
                     <name>env.HTTP_PROXY</name>
                 </property>

--- a/opensuse-tomcat-jre21-image/pom.xml
+++ b/opensuse-tomcat-jre21-image/pom.xml
@@ -170,7 +170,10 @@
         <profile>
             <id>docker-proxy</id>
             <activation>
-                <activeByDefault>true</activeByDefault>
+                <activeByDefault>false</activeByDefault>
+                <property>
+                    <name>env.HTTP_PROXY</name>
+                </property>
             </activation>
             <build>
                 <plugins>

--- a/opensuse-tomcat-jre21-juli-image/pom.xml
+++ b/opensuse-tomcat-jre21-juli-image/pom.xml
@@ -122,7 +122,6 @@
         <profile>
             <id>docker-proxy</id>
             <activation>
-                <activeByDefault>false</activeByDefault>
                 <property>
                     <name>env.HTTP_PROXY</name>
                 </property>

--- a/opensuse-tomcat-jre21-juli-image/pom.xml
+++ b/opensuse-tomcat-jre21-juli-image/pom.xml
@@ -122,7 +122,10 @@
         <profile>
             <id>docker-proxy</id>
             <activation>
-                <activeByDefault>true</activeByDefault>
+                <activeByDefault>false</activeByDefault>
+                <property>
+                    <name>env.HTTP_PROXY</name>
+                </property>
             </activation>
             <build>
                 <plugins>


### PR DESCRIPTION
## Overview

This change tweaks the `docker-proxy` profile so that it only activates if the `HTTP_PROXY` environment variable is defined.