### PR TITLE
D1125027: Remove profile to enable images to start in build

### DIFF
--- a/opensuse-tomcat-jre21-image/pom.xml
+++ b/opensuse-tomcat-jre21-image/pom.xml
@@ -109,6 +109,12 @@
                             <name>${dockerCafImagePrefix}opensuse-tomcat-jre21${dockerProjectVersion}</name>
                             <build>
                                 <dockerFileDir>.</dockerFileDir>
+                                <args>
+                                    <!-- Enable internet access -->
+                                    <http_proxy>${env.HTTP_PROXY}</http_proxy>
+                                    <https_proxy>${env.HTTPS_PROXY}</https_proxy>
+                                    <no_proxy>${env.NO_PROXY}</no_proxy>
+                                </args>
                                  <assembly>
                                     <basedir>/</basedir>
                                     <inline>
@@ -165,37 +171,4 @@
             </plugin>
         </plugins>
     </build>
-    <profiles>
-        <!-- profile for docker proxy settings -->
-        <profile>
-            <id>docker-proxy</id>
-            <activation>
-                <property>
-                    <name>env.HTTP_PROXY</name>
-                </property>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>io.fabric8</groupId>
-                        <artifactId>docker-maven-plugin</artifactId>
-                        <configuration>
-                            <images>
-                                <image>
-                                    <build>
-                                        <args>
-                                            <!-- Enable internet access -->
-                                            <http_proxy>${env.HTTP_PROXY}</http_proxy>
-                                            <https_proxy>${env.HTTPS_PROXY}</https_proxy>
-                                            <no_proxy>${env.NO_PROXY}</no_proxy>
-                                        </args>
-                                    </build>
-                                </image>
-                            </images>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-    </profiles>
 </project>

--- a/opensuse-tomcat-jre21-juli-image/pom.xml
+++ b/opensuse-tomcat-jre21-juli-image/pom.xml
@@ -76,6 +76,12 @@
                             <name>${dockerCafImagePrefix}opensuse-tomcat-jre21-juli${dockerProjectVersion}</name>
                             <build>
                                 <dockerFileDir>.</dockerFileDir>
+                                <args>
+                                    <!-- Enable internet access -->
+                                    <http_proxy>${env.HTTP_PROXY}</http_proxy>
+                                    <https_proxy>${env.HTTPS_PROXY}</https_proxy>
+                                    <no_proxy>${env.NO_PROXY}</no_proxy>
+                                </args>
                             </build>
                         </image>
                         <image>
@@ -117,37 +123,4 @@
             </plugin>
         </plugins>
     </build>
-    <profiles>
-        <!-- profile for docker proxy settings -->
-        <profile>
-            <id>docker-proxy</id>
-            <activation>
-                <property>
-                    <name>env.HTTP_PROXY</name>
-                </property>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>io.fabric8</groupId>
-                        <artifactId>docker-maven-plugin</artifactId>
-                        <configuration>
-                            <images>
-                                <image>
-                                    <build>
-                                        <args>
-                                            <!-- Enable internet access -->
-                                            <http_proxy>${env.HTTP_PROXY}</http_proxy>
-                                            <https_proxy>${env.HTTPS_PROXY}</https_proxy>
-                                            <no_proxy>${env.NO_PROXY}</no_proxy>
-                                        </args>
-                                    </build>
-                                </image>
-                            </images>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-    </profiles>
 </project>


### PR DESCRIPTION
Ticket: https://internal.almoctane.com/ui/entity-navigation?p=131002/6001&entityType=work_item&id=1125027

Not sure why this works but it was the only difference I could find between jre17 tomcat images and this one.